### PR TITLE
Support Drag and Drop Upload

### DIFF
--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -9,7 +9,6 @@ import {
 	RangeControl,
 	Spinner,
 	SelectControl,
-	withNotices,
 	// @ts-ignore: has no exported member
 	__experimentalHStack as HStack,
 	// @ts-ignore: has no exported member
@@ -19,13 +18,12 @@ import {
 } from '@wordpress/components';
 
 import { MediaUpload, store as blockEditorStore } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 import { filterURLForDisplay } from '@wordpress/url';
 import { isBlobURL } from '@wordpress/blob';
-
-import type { WithNoticeProps } from '@wordpress/components/src/higher-order/with-notices/types';
 
 /**
  * Internal dependencies
@@ -42,9 +40,9 @@ type Props = {
 	onRemove: () => void;
 	onChangeOrder?: ( direction: number ) => void;
 	isSelected: boolean;
-} & WithNoticeProps;
+};
 
-export default withNotices( function SourceEditor( {
+export default function SourceEditor( {
 	source = {
 		srcset: undefined,
 		id: undefined,
@@ -59,8 +57,6 @@ export default withNotices( function SourceEditor( {
 	onChange,
 	onRemove,
 	isSelected,
-	noticeUI,
-	noticeOperations,
 }: Props ) {
 	const { id, srcset, mediaType, mediaValue, slug: srcsetSlug } = source;
 	const { image } = useSelect(
@@ -85,6 +81,8 @@ export default withNotices( function SourceEditor( {
 		} ),
 		[]
 	);
+
+	const { createErrorNotice, removeAllNotices } = useDispatch( noticesStore );
 
 	const [ isLoading, setIsLoading ] = useState( false );
 
@@ -162,15 +160,14 @@ export default withNotices( function SourceEditor( {
 				setIsLoading( false );
 			},
 			onError( message: string ) {
-				noticeOperations.removeAllNotices();
-				noticeOperations.createErrorNotice( message );
+				removeAllNotices();
+				createErrorNotice( message, { type: 'snackbar' } );
 			},
 		} );
 	}
 
 	return (
 		<>
-			{ noticeUI }
 			<MediaUpload
 				onSelect={ onSelectImage }
 				allowedTypes={ [ 'image' ] }
@@ -269,4 +266,4 @@ export default withNotices( function SourceEditor( {
 			) }
 		</>
 	);
-} );
+}

--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -5,16 +5,17 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
-	RangeControl,
-	SelectControl,
 	DropZone,
+	RangeControl,
+	Spinner,
+	SelectControl,
 	withNotices,
 	// @ts-ignore: has no exported member
 	__experimentalHStack as HStack,
 	// @ts-ignore: has no exported member
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	// @ts-ignore: has no exported member
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption, Spinner,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 
 import { MediaUpload, store as blockEditorStore } from '@wordpress/block-editor';
@@ -32,7 +33,6 @@ import type { WithNoticeProps } from '@wordpress/components/src/higher-order/wit
 import type { Media, Source } from './types';
 import { DEFAULT_MEDIA_VALUE, MEDIA_TYPES, MIN_MEDIA_VALUE, MAX_MEDIA_VALUE } from './constants';
 
-
 type Props = {
 	source?: Source;
 	disableMoveUp: boolean;
@@ -44,7 +44,7 @@ type Props = {
 	isSelected: boolean;
 } & WithNoticeProps;
 
-export default withNotices(function SourceEditor( {
+export default withNotices( function SourceEditor( {
 	source = {
 		srcset: undefined,
 		id: undefined,
@@ -76,17 +76,17 @@ export default withNotices(function SourceEditor( {
 		[ id, isSelected ]
 	);
 
-	const { mediaUpload, imageSizes } = useSelect( ( select ) => (
-		{
+	const { mediaUpload, imageSizes } = useSelect(
+		( select ) => ( {
 			// @ts-ignore
 			imageSizes: select( blockEditorStore ).getSettings().imageSizes,
 			// @ts-ignore
 			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
-		}
-	), [] );
+		} ),
+		[]
+	);
 
 	const [ isLoading, setIsLoading ] = useState( false );
-
 
 	const imageSizeOptions = imageSizes
 		.filter( ( { slug }: { slug: string } ) => {
@@ -149,17 +149,16 @@ export default withNotices(function SourceEditor( {
 		} );
 	}
 
-
 	function onDropFiles( filesList: File[] ) {
 		mediaUpload( {
 			allowedTypes: [ 'image' ],
 			filesList,
-			onFileChange( [ image ]: Media[] ) {
-				if ( isBlobURL( image?.url ) ) {
+			onFileChange( [ newImage ]: Media[] ) {
+				if ( isBlobURL( newImage?.url ) ) {
 					setIsLoading( true );
 					return;
 				}
-				onSelectImage( image );
+				onSelectImage( newImage );
 				setIsLoading( false );
 			},
 			onError( message: string ) {
@@ -185,8 +184,10 @@ export default withNotices(function SourceEditor( {
 						>
 							{ !! id && srcset ? (
 								<img src={ srcset } alt="" />
+							) : isLoading ? (
+								<Spinner />
 							) : (
-								isLoading ? <Spinner /> : __( 'Set image source', 'enable-responsive-image' )
+								__( 'Set image source', 'enable-responsive-image' )
 							) }
 						</Button>
 						<HStack className="enable-responsive-image__movers" expanded={ false }>
@@ -268,4 +269,4 @@ export default withNotices(function SourceEditor( {
 			) }
 		</>
 	);
-});
+} );

--- a/src/source-list.tsx
+++ b/src/source-list.tsx
@@ -83,8 +83,8 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 											sources.length === 1 && ! sources[ 0 ].id && ! sources[ 0 ].srcset
 										}
 										source={ source }
-										onChangeOrder={ ( direction ) => onChangeOrder( direction, index ) }
-										onChange={ ( newSource ) => onChange( newSource, index ) }
+										onChangeOrder={ ( direction: number ) => onChangeOrder( direction, index ) }
+										onChange={ ( newSource: Source ) => onChange( newSource, index ) }
 										onRemove={ () => onRemoveSource( index ) }
 									/>
 									{ index < sources.length - 1 && <hr /> }
@@ -112,7 +112,7 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 							disableMoveUp={ true }
 							disableMoveDown={ true }
 							disableActions={ true }
-							onChange={ ( newSource ) => onChange( newSource, 0 ) }
+							onChange={ ( newSource: Source ) => onChange( newSource, 0 ) }
 							onRemove={ () => onRemoveSource( 0 ) }
 						/>
 					) }


### PR DESCRIPTION
Enabled drag-and-drop image uploading.

@see https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/post-featured-image/index.js#L225

https://github.com/t-hamano/enable-responsive-image/assets/1908815/68f6ed11-1388-455b-b19f-26f41419aaf9

