### PR TITLE
Fix: browser warning error when dropping a file other than an image

### DIFF
--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -96,14 +96,8 @@ export default function SourceEditor( {
 		} ) );
 
 	function onSelectImage( media: Media ) {
-		if ( ! media || ! media.url ) {
-			onChange( {
-				srcset: undefined,
-				id: undefined,
-				slug: undefined,
-				mediaType: undefined,
-				mediaValue: undefined,
-			} );
+		if ( ! media ) {
+			return;
 		}
 
 		onChange( {


### PR DESCRIPTION
This PR fixes a browser warning error that occurs when dropping files with certain extensions. At least it seems to happen with the markdown file.

https://github.com/t-hamano/enable-responsive-image/assets/54422211/c8033f43-a727-4f8b-9a2e-35337a5185ed